### PR TITLE
docs: remove extra dots

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,5 +54,3 @@ Here you can see How to Use, Installation, Command List, Contributing Guidelines
 - [Hololive](https://www.hololive.tv)
 - [holoX (Hololive Generation 6)](https://hololive.hololivepro.com/en/special/3268/)
 - [博衣こより (Hakui Koyori) Herself](https://twitter.com/hakuikoyori)
-
----

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,3 @@ Here you can see How to Use, Installation, Command List, Contributing Guidelines
 - [博衣こより (Hakui Koyori) Herself](https://twitter.com/hakuikoyori)
 
 ---
-
-## 📃 License
-
-[Koyorin](https://github.com/gifaldyazkaa/koyorin) is Licensed under [Apache-2.0](https://github.com/gifaldyazkaa/koyorin/blob/master/LICENSE) License.

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -34,8 +34,8 @@
       {{ content }}
 
       <footer class="site-footer">
-          <span class="site-footer-owner"><a href="{{ site.github.repository_url }}">Koyorin</a> is Licensed under <a href="https://github.com/gifaldyazkaa/koyorin/blob/master/LICENSE">Apache 2.0</a>.</span>
-          <span class="site-footer-owner">Issues? Let us know on <a href="https://github.com/gifaldyazkaa/koyorin/issues/new">GitHub</a>.</span>
+          <span class="site-footer-owner"><a href="{{ site.github.repository_url }}">Koyorin</a> is Licensed under <a href="https://github.com/gifaldyazkaa/koyorin/blob/master/LICENSE">Apache 2.0</a></span>
+          <span class="site-footer-owner">Issues? Let us know on <a href="https://github.com/gifaldyazkaa/koyorin/issues/new">GitHub</a></span>
       </footer>
     </main>
   </body>


### PR DESCRIPTION
Remove extra dots at documentation and Remove license section from Homepage